### PR TITLE
Make sure getMessages() doesn't run multiple times at once

### DIFF
--- a/frontend.html
+++ b/frontend.html
@@ -67,6 +67,7 @@
         const adminButton = document.getElementById("admin-btn");
 
         let isAdminMode = false;
+        var gettingMessages = false;
 
         function handleKeyDown(event) {
             // Check if Enter is pressed without Shift
@@ -139,10 +140,14 @@
         }
 
         function getMessages() {
+            if (gettingMessages) return; // don't send multiple requests at the same time
+            gettingMessage = true;
+            
             fetch(`${apiUrl}/api/messages`)
                 .then(response => response.json())
                 .then(data => {
-                    setTimeout(getMessages, 1000);
+                    // at this point the http request has finished and we can send another one
+                    gettingMessage = false;
                     
                     const messageList = document.getElementById("message-list");
                     const olderMessageList = document.getElementById("older-message-list");
@@ -188,6 +193,7 @@
                     }
                 })
                 .catch(error => {
+                    gettingMessage = false;
                     console.log(error);
                 });
         }
@@ -294,5 +300,5 @@
                 adminButton.style.display = "none";
             }
         };
-        setTimeout(getMessages, 1);
+        setInterval(getMessages, 1000);
     </script>

--- a/frontend.html
+++ b/frontend.html
@@ -142,6 +142,8 @@
             fetch(`${apiUrl}/api/messages`)
                 .then(response => response.json())
                 .then(data => {
+                    setTimeout(getMessages, 1000);
+                    
                     const messageList = document.getElementById("message-list");
                     const olderMessageList = document.getElementById("older-message-list");
                     messageList.innerHTML = "";
@@ -292,5 +294,5 @@
                 adminButton.style.display = "none";
             }
         };
-        setInterval(getMessages, 1000);
+        setTimeout(getMessages, 1);
     </script>


### PR DESCRIPTION
Currently the frontend will try to update the messages every second, even if the previous attempt has not finished. If the server slows down enough that it can't process the requests fast enough they will start to pile up and slow down the server.
This change ensures only one request can happen at a time so this issue doesn't happen.